### PR TITLE
ci: automate PR governance and upstream branch sync

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+* @brandonroberts
+
+/apps/docs-app/ @benpsnyder
+/apps/trpc-app/ @benpsnyder
+/apps/trpc-app-e2e-playwright/ @benpsnyder

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,36 @@
 
 Closes #
 
+## Affected scope
+
+<!-- List the primary scope from CONTRIBUTING.md and any closely related secondary scopes. -->
+
+- Primary scope:
+- Secondary scopes:
+
+## Recommended merge strategy for maintainer [optional]
+
+<!-- This is a recommendation for maintainers, not a requirement. -->
+<!-- Prefer rebase merge when this PR intentionally preserves multiple related commits. -->
+
+- [ ] Rebase merge
+- [ ] Squash merge
+- [ ] No preference
+
+## Why preserve commits? [optional]
+
+<!-- If you recommend rebase merge, explain the commit boundaries maintainers should preserve. -->
+
 ## What is the new behavior?
+
+## Test plan
+
+<!-- List the commands you ran and any manual verification you performed. -->
+
+- [ ] `pnpm prettier:check`
+- [ ] Relevant `nx build <project>`
+- [ ] Relevant `nx test <project>`
+- [ ] Manual verification
 
 ## Does this PR introduce a breaking change?
 

--- a/.github/pr-scope-map.json
+++ b/.github/pr-scope-map.json
@@ -1,0 +1,152 @@
+{
+  "areas": [
+    {
+      "scope": "astro-angular",
+      "label": "scope:astro-angular",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/astro-angular",
+      "prefixes": ["packages/astro-angular/"]
+    },
+    {
+      "scope": "content",
+      "label": "scope:content",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/content",
+      "prefixes": ["packages/content/"]
+    },
+    {
+      "scope": "content-plugin",
+      "label": "scope:content-plugin",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/content-plugin",
+      "prefixes": ["packages/content-plugin/"]
+    },
+    {
+      "scope": "create-analog",
+      "label": "scope:create-analog",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in create-analog",
+      "prefixes": ["packages/create-analog/"]
+    },
+    {
+      "scope": "nx-plugin",
+      "label": "scope:nx-plugin",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/nx-plugin",
+      "prefixes": ["packages/nx-plugin/", "apps/nx-plugin-e2e/"]
+    },
+    {
+      "scope": "platform",
+      "label": "scope:platform",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/platform",
+      "prefixes": ["packages/platform/"]
+    },
+    {
+      "scope": "router",
+      "label": "scope:router",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/router",
+      "prefixes": ["packages/router/"]
+    },
+    {
+      "scope": "storybook-angular",
+      "label": "scope:storybook-angular",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/storybook-angular",
+      "prefixes": ["packages/storybook-angular/"]
+    },
+    {
+      "scope": "trpc",
+      "label": "scope:trpc",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/trpc",
+      "prefixes": [
+        "packages/trpc/",
+        "apps/trpc-app/",
+        "apps/trpc-app-e2e-playwright/"
+      ]
+    },
+    {
+      "scope": "vite-plugin-angular",
+      "label": "scope:vite-plugin-angular",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/vite-plugin-angular",
+      "prefixes": ["packages/vite-plugin-angular/"]
+    },
+    {
+      "scope": "vite-plugin-nitro",
+      "label": "scope:vite-plugin-nitro",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/vite-plugin-nitro",
+      "prefixes": ["packages/vite-plugin-nitro/"]
+    },
+    {
+      "scope": "vitest-angular",
+      "label": "scope:vitest-angular",
+      "kind": "package",
+      "color": "0e8a16",
+      "description": "Changes in @analogjs/vitest-angular",
+      "prefixes": [
+        "packages/vitest-angular/",
+        "packages/vitest-angular-tools/",
+        "tests/vitest-angular/"
+      ]
+    },
+    {
+      "scope": "docs",
+      "label": "scope:docs",
+      "kind": "auxiliary",
+      "color": "fbca04",
+      "description": "Documentation changes",
+      "prefixes": ["apps/docs-app/"],
+      "files": [
+        "README.md",
+        "CONTRIBUTING.md",
+        "CHANGELOG.md",
+        "CODE_OF_CONDUCT.md",
+        "MAINTAINER.md"
+      ]
+    },
+    {
+      "scope": "ci",
+      "label": "scope:ci",
+      "kind": "auxiliary",
+      "color": "5319e7",
+      "description": "GitHub workflow changes",
+      "prefixes": [".github/workflows/"]
+    },
+    {
+      "scope": "repo",
+      "label": "scope:repo",
+      "kind": "auxiliary",
+      "color": "6e7781",
+      "description": "Repository metadata and tooling",
+      "prefixes": [".githooks/"],
+      "files": [
+        ".github/CODEOWNERS",
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        ".github/pr-scope-map.json",
+        "AGENTS.md",
+        "commitlint.config.cjs",
+        "nx.json",
+        "package.json",
+        "pnpm-workspace.yaml",
+        "release.config.cjs",
+        "server.mjs",
+        "tsconfig.base.json"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/pr-scope-governance.yml
+++ b/.github/workflows/pr-scope-governance.yml
@@ -1,0 +1,185 @@
+name: pr-scope-governance
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  apply-scope-metadata:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const marker = '<!-- pr-scope-governance -->';
+            const config = JSON.parse(
+              fs.readFileSync('.github/pr-scope-map.json', 'utf8')
+            );
+            const pr = context.payload.pull_request;
+
+            const changedFiles = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              }
+            );
+
+            const filenames = changedFiles.map((file) => file.filename);
+            const matches = config.areas.filter((area) => {
+              const prefixes = area.prefixes ?? [];
+              const files = area.files ?? [];
+
+              return filenames.some((filename) => {
+                return (
+                  prefixes.some((prefix) => filename.startsWith(prefix)) ||
+                  files.includes(filename)
+                );
+              });
+            });
+
+            const matchedLabels = [...new Set(matches.map((area) => area.label))];
+            const managedLabels = config.areas.map((area) => area.label);
+
+            for (const area of config.areas) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: area.label,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: area.label,
+                  color: area.color,
+                  description: area.description,
+                });
+              }
+            }
+
+            const issueLabels = await github.paginate(
+              github.rest.issues.listLabelsOnIssue,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              }
+            );
+
+            const currentManaged = issueLabels
+              .map((label) => label.name)
+              .filter((label) => managedLabels.includes(label));
+
+            const labelsToAdd = matchedLabels.filter(
+              (label) => !currentManaged.includes(label)
+            );
+            const labelsToRemove = currentManaged.filter(
+              (label) => !matchedLabels.includes(label)
+            );
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: labelsToAdd,
+              });
+            }
+
+            for (const label of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            const packageMatches = matches.filter(
+              (area) => area.kind === 'package'
+            );
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              }
+            );
+
+            const existingComment = comments.find(
+              (comment) =>
+                comment.user?.type === 'Bot' &&
+                comment.body?.includes(marker)
+            );
+
+            if (packageMatches.length > 1) {
+              const scopes = packageMatches
+                .map((area) => `\`${area.scope}\``)
+                .join(', ');
+
+              const body = [
+                marker,
+                `This PR touches multiple package scopes: ${scopes}.`,
+                '',
+                'Please confirm the changes are closely related. If the commit boundaries are intentional, recommend `Rebase merge` in the PR template and explain which commits should be preserved.',
+              ].join('\n');
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body,
+                });
+              }
+            } else if (existingComment) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+              });
+            }
+
+            core.info(`Changed files: ${filenames.join(', ')}`);
+            core.info(`Matched labels: ${matchedLabels.join(', ') || 'none'}`);

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,92 @@
+name: pr-title
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Validate pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          node <<'EOF'
+          const config = require('./commitlint.config.cjs');
+
+          const allowedTypes = new Set([
+            'build',
+            'ci',
+            'docs',
+            'feat',
+            'fix',
+            'perf',
+            'refactor',
+            'style',
+            'test',
+          ]);
+          const optionalScopeTypes = new Set([
+            'build',
+            'ci',
+            'docs',
+            'refactor',
+            'style',
+            'test',
+          ]);
+          const scopes = new Set(config.rules['scope-enum']?.[2] ?? []);
+          const title = (process.env.PR_TITLE ?? '').trim();
+
+          const match = title.match(
+            /^(build|ci|docs|feat|fix|perf|refactor|style|test)(?:\(([a-z0-9-]+)\))?(!)?: (.+)$/
+          );
+
+          if (!match) {
+            console.error(
+              'Pull request titles must use Conventional Commit style, for example `feat(router): add route metadata support`.'
+            );
+            process.exit(1);
+          }
+
+          const [, type, scope, , subject] = match;
+
+          if (!allowedTypes.has(type)) {
+            console.error(`Unsupported PR title type: ${type}`);
+            process.exit(1);
+          }
+
+          if (!subject.trim()) {
+            console.error('Pull request titles must include a subject after `: `.');
+            process.exit(1);
+          }
+
+          if (scope && !scopes.has(scope)) {
+            console.error(
+              `Unsupported PR title scope: ${scope}. Allowed scopes: ${[
+                ...scopes,
+              ].join(', ')}`
+            );
+            process.exit(1);
+          }
+
+          if (!scope && !optionalScopeTypes.has(type)) {
+            console.error(
+              `Pull request titles for \`${type}\` changes should include a package scope, for example \`${type}(router): ...\`.`
+            );
+            process.exit(1);
+          }
+
+          console.log(`Validated PR title: ${title}`);
+          EOF

--- a/.github/workflows/sync-upstream-branches.yml
+++ b/.github/workflows/sync-upstream-branches.yml
@@ -1,0 +1,75 @@
+name: Sync Upstream Branches
+
+on:
+  schedule:
+    - cron: '17 */3 * * *'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to sync'
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - alpha
+          - beta
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-upstream-branches
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - alpha
+          - beta
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.branch == 'all' || inputs.branch == matrix.branch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync branch from upstream
+        run: |
+          workflow_path=".github/workflows/sync-upstream-branches.yml"
+          temp_workflow="$(mktemp)"
+
+          cp "$workflow_path" "$temp_workflow"
+          git remote add upstream https://github.com/analogjs/analog.git
+          git fetch --no-tags upstream ${{ matrix.branch }}
+          git fetch --no-tags origin ${{ matrix.branch }} || true
+
+          git checkout -B ${{ matrix.branch }} upstream/${{ matrix.branch }}
+
+          mkdir -p "$(dirname "$workflow_path")"
+          cp "$temp_workflow" "$workflow_path"
+          git add "$workflow_path"
+
+          DESIRED_TREE="$(git write-tree)"
+          ORIGIN_TREE="$(git rev-parse origin/${{ matrix.branch }}^{tree} 2>/dev/null || true)"
+
+          if [ "$DESIRED_TREE" = "$ORIGIN_TREE" ]; then
+            echo "${{ matrix.branch }} is already up to date"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Keep each branch synced to upstream while preserving this workflow.
+          git commit -m "chore(repo): sync ${{ matrix.branch }} from upstream"
+
+          if git rev-parse origin/${{ matrix.branch }} >/dev/null 2>&1; then
+            git push origin HEAD:${{ matrix.branch }} --force-with-lease
+          else
+            git push origin HEAD:${{ matrix.branch }}
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,6 @@ This is the monorepo that contains all the code and infrastructure for AnalogJS.
 - `nx build <package-name>` to verify build
 - For E2E: `nx e2e create-analog-e2e` or `nx e2e analog-app-e2e-cypress`
 - Run `pnpm prettier:check` to verify formatting
-- Always validate existing tests and builds pass before submitting changes
 
 ## Project Structure & Conventions
 
@@ -65,12 +64,21 @@ This is the monorepo that contains all the code and infrastructure for AnalogJS.
 | `packages/trpc`                | `@analogjs/trpc`                | `trpc`                |
 | `packages/astro-angular`       | `@analogjs/astro-angular`       | `astro-angular`       |
 
-## Branch Strategy
+## Contribution Policy
 
-- Base branch: `beta`
-- PRs should be rebased against `beta`
-- Conventional Commits required for PR titles (e.g., `feat(platform): add new feature`)
-- Commit types: `feat`, `fix`, `docs`, `build`, `ci`, `perf`, `refactor`, `style`, `test`
+- Use `CONTRIBUTING.md` as the source of truth for base branch, PR requirements, title and commit conventions, supported types/scopes, breaking change notes, and submission expectations.
+- Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure, including affected scope, test plan, and maintainer-facing merge-strategy recommendations.
+
+## Commit Review Workflow
+
+- Before reviewing branch history, run `git fetch --all`.
+- Treat `https://github.com/analogjs/analog.git` as the upstream source of truth and compare the current branch against the relevant `analogjs/*` remote branch.
+- If the branch mixes multiple packages or concerns, recommend `git reset --soft <base-commit>` and re-commit the staged changes into smaller, policy-aligned groups.
+- Prefer regrouping by affected package or primary package scope using the directory mapping above.
+- Before changing GitHub metadata, ask whether the user wants the PR title and description updated. If no PR exists for the branch, ask whether they want one created.
+- When a PR intentionally preserves multiple related commits across distinct areas, note in the PR description that the author recommends `rebase merge` so maintainers can preserve commit boundaries.
+- When recommending `rebase merge`, include a short explanation of which commit boundaries should be preserved.
+- If history is rewritten, remind the user that they can run `git push --force`, but do not do it on their behalf unless they explicitly ask.
 
 ## Nx Usage
 
@@ -83,7 +91,6 @@ This is the monorepo that contains all the code and infrastructure for AnalogJS.
 
 - Keep changes minimal and targeted.
 - Backward compatibility is critical for new features, allowing progressive adoption.
-- Only make changes to one package/app at a time unless absolutely necessary.
 - Keep code concise with emphasis on readability, avoid clever solutions and abstractions.
 - Always scan existing codebase for examples and patterns for implementation.
 - Prefer using existing Angular APIs, with wrappers where needed.
@@ -97,9 +104,7 @@ This is the monorepo that contains all the code and infrastructure for AnalogJS.
 
 - Add Angular SFC references to features or docs
 - Create new abstractions for one-time operations
-- Modify multiple packages in a single PR unless necessary
 - Add verbose comments, docstrings, or type annotations to code you didn't change
-- Skip running existing tests before submitting changes
 - Add error handling or validation for scenarios that can't happen
 - Design for hypothetical future requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,8 @@ pnpm nx serve-static docs-app
 - If you've added new functionality, **please** include tests which validate its behavior.
 - Make reference to possible [issues](https://github.com/analogjs/analog/issues) on PR comment.
 - PRs may include multiple commits. However, please keep content of all commits related. Raise separate PRs for disjoint changes.
+- Use the PR template to capture the affected scope, your test plan, and any maintainer-facing merge recommendation.
+- If you recommend `rebase merge`, explain why the commit boundaries should be preserved.
 
 ### Pull Request title guidelines
 
@@ -155,6 +157,8 @@ Must be one of the following:
 ### Scope
 
 The scope should be the name of the npm package affected (as perceived by the person reading the changelog generated from commit messages).
+
+PR titles are validated in GitHub using the supported types and scopes below.
 
 The following is the list of currently supported scopes:
 


### PR DESCRIPTION
Closes #

## Affected scope

- Primary scope: `ci`
- Secondary scopes: `docs`, `repo`

## Recommended merge strategy for maintainer [optional]

- [ ] Rebase merge
- [x] Squash merge
- [ ] No preference

## Why preserve commits? [optional]

Single-commit PR, so there are no commit boundaries to preserve.

## What is the new behavior?

- add PR title validation for conventional GitHub PR titles
- add scope labeling and multi-scope warning automation for pull requests
- add `CODEOWNERS` plus clearer PR guidance in `CONTRIBUTING.md`, `AGENTS.md`, and the PR template
- add an upstream branch sync workflow that preserves repo-specific automation

## Test plan

- [ ] `pnpm prettier:check`
- [ ] Relevant `nx build <project>`
- [ ] Relevant `nx test <project>`
- [x] Manual verification

Manual verification performed:
- validated `.github/workflows/pr-title.yml` and `.github/workflows/pr-scope-governance.yml` parse as YAML
- validated `.github/pr-scope-map.json` parses as JSON
- checked edited files for diagnostics with `ReadLints`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This intentionally leaves local `plans/` and `research/` directories out of the commit.

Made with [Cursor](https://cursor.com)